### PR TITLE
Add xxxxf functions to standardize and enable tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # flog
 
+[![GitHub Release](https://img.shields.io/github/v/release/cdr/flog?color=6b9ded&sort=semver)](https://github.com/cdr/flog/releases)
+[![GoDoc](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white)](https://pkg.go.dev/go.coder.com/flog?tab=doc)
+[![license](https://img.shields.io/github/license/cdr/flog)](https://raw.githubusercontent.com/cdr/flog/master/LICENSE)
+
 `flog` is a minimal, formatted, pretty logging package for Go.
 
 It's optimized for human readability.
 
 [slog](https://github.com/cdr/slog) is recommended for more robust logging.
-
-[![GoDoc](https://godoc.org/github.com/golang/gddo?status.svg)](https://godoc.org/go.coder.com/flog)
 
 ## Install
 
@@ -15,13 +17,13 @@ It's optimized for human readability.
 ## Usage
 
 ```go
-flog.Info("hello %.3f", 1/3.0)
-flog.Success("finished that")
-flog.Error("oops")
+flog.Infof("hello %.3f", 1/3.0)
+flog.Successf("finished that")
+flog.Errorf("oops")
 
-log := flog.NewLogger().WithPrefix("user %v: ", 500)
+log := flog.NewLogger().WithPrefixf("user %d: ", 500)
 
-log.Error("didn't work out")
+log.Errorf("didn't work out")
 ```
 
 produces
@@ -29,3 +31,37 @@ produces
 ![example](docs/usage.png)
 
 
+## Linter settings
+
+By default, the linters will not understand that `flog` is a logging library expected formatting. To fix this, we need to update the settings.
+
+### golangci-lint
+
+When using [golangci-lint](https://github.com/golangci/golangci-lint), the `govet` settings can be set in the `.golangci.yml` file:
+
+```yaml
+linters-settings:
+  govet:
+    settings:
+      printf: # Analyzer name.
+        funcs: # Run `go tool vet help printf` to see available settings for `printf` analyzer.
+          - (go.coder.com/flog).Errorf
+          - (go.coder.com/flog).Fatalf
+          - (go.coder.com/flog).Infof
+          - (go.coder.com/flog).Logf
+          - (go.coder.com/flog).Successf
+          - (*go.coder.com/flog.Logger).Errorf
+          - (*go.coder.com/flog.Logger).Fatalf
+          - (*go.coder.com/flog.Logger).Infof
+          - (*go.coder.com/flog.Logger).Logf
+          - (*go.coder.com/flog.Logger).Successf
+          - (*go.coder.com/flog.Logger).WithPrefixf
+```
+
+### go vet
+
+When using `go vet` directly, `-printf.funcs` can be used.
+
+```bash
+go vet -printf.funcs Errorf,Fatalf,Infof,Logf,Successf,WithPrefixf ./...
+```

--- a/log.go
+++ b/log.go
@@ -10,77 +10,139 @@ import (
 	"github.com/fatih/color"
 )
 
+// Level enum type, representing the severity level of a log entry.
 type Level string
 
+// Level enum values.
 var (
-	INFO    = Level(color.HiBlueString("INFO"))
-	SUCCESS = Level(color.HiGreenString("SUCCESS"))
-	ERROR   = Level(color.RedString("ERROR"))
-	FATAL   = Level(color.RedString("FATAL"))
+	InfoLevel    = Level(color.HiBlueString("INFO"))
+	SuccessLevel = Level(color.HiGreenString("SUCCESS"))
+	ErrorLevel   = Level(color.RedString("ERROR"))
+	FatalLevel   = Level(color.RedString("FATAL"))
 )
 
+// Deprecated: Upper case values exists for historical compatibility
+// and should not be used. Prefer the linted, capitalized xxxLevel version.
+var (
+	INFO    = InfoLevel
+	SUCCESS = SuccessLevel
+	ERROR   = ErrorLevel
+	FATAL   = FatalLevel
+)
+
+// Time format used as prefix in all log messages.
+const timePrefixFormat = `2006-01-02 15:04:05`
+
+// Logger is the main logger struct, wrapping a writer and settings.
 type Logger struct {
 	W      io.Writer
 	Prefix string
 }
 
-func (l *Logger) WithPrefix(p string, args ...interface{}) *Logger {
+// WithPrefixf makes creates a copy of the logger and sets a appends the given prefix to it.
+func (l *Logger) WithPrefixf(p string, args ...interface{}) *Logger {
 	ll := *l
 	ll.Prefix += fmt.Sprintf(p, args...)
+
 	return &ll
 }
 
-func (l *Logger) Info(msg string, args ...interface{}) {
-	l.Log(INFO, msg, args...)
-}
+// Infof logs an entry with the Infof level.
+func (l *Logger) Infof(msg string, args ...interface{}) { l.Logf(InfoLevel, msg, args...) }
 
-func (l *Logger) Success(msg string, args ...interface{}) {
-	l.Log(SUCCESS, msg, args...)
-}
+// Successf logs an entry with the Successf level.
+func (l *Logger) Successf(msg string, args ...interface{}) { l.Logf(SuccessLevel, msg, args...) }
 
-func (l *Logger) Error(msg string, args ...interface{}) {
-	l.Log(ERROR, msg, args...)
-}
+// Errorf logs an entry with the Errorf level.
+func (l *Logger) Errorf(msg string, args ...interface{}) { l.Logf(ErrorLevel, msg, args...) }
 
-func (l *Logger) Fatal(msg string, args ...interface{}) {
-	l.Log(FATAL, msg, args...)
-}
+// Fatalf logs an entry with the Fatalf level. Exits the process.
+func (l *Logger) Fatalf(msg string, args ...interface{}) { l.Logf(FatalLevel, msg, args...) }
 
-func (l *Logger) Log(lvl Level, msg string, args ...interface{}) {
-	fmt.Fprintf(
-		l.W,
-		fmt.Sprintf("%v %v\t", time.Now().Format(`2006-01-02 15:04:05`), lvl)+l.Prefix+msg+"\n",
-		args...,
+// Logf the given message with a severity level. If Fatal, exits the process.
+func (l *Logger) Logf(lvl Level, msg string, args ...interface{}) {
+	fmt.Fprintf(l.W, //  Log to the underlying writer.
+		"%s %s\t%s%s\n", // [current time] [severity level]\t[preset perfix][formatted msg].
+		time.Now().Format(timePrefixFormat),
+		lvl,
+		l.Prefix,
+		fmt.Sprintf(msg, args...),
 	)
-	if lvl == FATAL {
+
+	if lvl == FatalLevel {
 		os.Exit(1)
 	}
 }
 
+// WithPrefix maps to WithPrefixf.
+// Deprecated: Non-standard and prevents tools like go vet to check for errors.
+// The xxxf version should be used.
+func (l *Logger) WithPrefix(p string, args ...interface{}) *Logger { return l.WithPrefixf(p, args...) }
+
+// Info maps to Infof.
+// Deprecated: Non-standard and prevents tools like go vet to check for errors.
+// The xxxf version should be used.
+func (l *Logger) Info(msg string, args ...interface{}) { l.Infof(msg, args...) }
+
+// Success maps to Successf.
+// Deprecated: Non-standard and prevents tools like go vet to check for errors.
+// The xxxf version should be used.
+func (l *Logger) Success(msg string, args ...interface{}) { l.Successf(msg, args...) }
+
+// Error maps to Errorf.
+// Deprecated: Non-standard and prevents tools like go vet to check for errors.
+// The xxxf version should be used.
+func (l *Logger) Error(msg string, args ...interface{}) { l.Errorf(msg, args...) }
+
+// Fatal maps to Fatalf.
+// Deprecated: Non-standard and prevents tools like go vet to check for errors.
+// The xxxf version should be used.
+func (l *Logger) Fatal(msg string, args ...interface{}) { l.Fatalf(msg, args...) }
+
+// Log maps to Logf.
+// Deprecated: Non-standard and prevents tools like go vet to check for errors.
+// The xxxf version should be used.
+func (l *Logger) Log(lvl Level, msg string, args ...interface{}) { l.Logf(lvl, msg, args...) }
+
 // New returns a new logger.
-func New() *Logger {
-	return &Logger{
-		W: os.Stderr,
-	}
-}
+func New() *Logger { return &Logger{W: os.Stderr} }
 
-func Info(msg string, args ...interface{}) {
-	New().Log(INFO, msg, args...)
-}
+// Infof creates a new default logger and logs an entry with the Infof level.
+func Infof(msg string, args ...interface{}) { New().Logf(InfoLevel, msg, args...) }
 
-func Success(msg string, args ...interface{}) {
-	New().Log(SUCCESS, msg, args...)
-}
+// Successf creates a new default logger and logs an entry with the Successf level.
+func Successf(msg string, args ...interface{}) { New().Logf(SuccessLevel, msg, args...) }
 
-func Error(msg string, args ...interface{}) {
-	New().Log(ERROR, msg, args...)
-}
+// Errorf creates a new default logger and logs an entry with the Errorf level.
+func Errorf(msg string, args ...interface{}) { New().Logf(ErrorLevel, msg, args...) }
 
-func Fatal(msg string, args ...interface{}) {
-	New().Log(FATAL, msg, args...)
-}
+// Fatalf creates a new default logger and logs an entry with the Fatalf level. Exits the process.
+func Fatalf(msg string, args ...interface{}) { New().Logf(FatalLevel, msg, args...) }
 
-// Log logs a message with the default logger.
-func Log(l Level, m string, args ...interface{}) {
-	New().Log(l, m, args...)
-}
+// Logf creates a new default logger and logs an entry with the given severity level.
+func Logf(l Level, m string, args ...interface{}) { New().Logf(l, m, args...) }
+
+// Info maps to Infof.
+// Deprecated: Non-standard and prevents tools like go vet to check for errors.
+// The xxxf version should be used.
+func Info(msg string, args ...interface{}) { Infof(msg, args...) }
+
+// Success maps to Successf.
+// Deprecated: Non-standard and prevents tools like go vet to check for errors.
+// The xxxf version should be used.
+func Success(msg string, args ...interface{}) { Successf(msg, args...) }
+
+// Error maps to Errorf.
+// Deprecated: Non-standard and prevents tools like go vet to check for errors.
+// The xxxf version should be used.
+func Error(msg string, args ...interface{}) { Errorf(msg, args...) }
+
+// Fatal maps to Fatalf.
+// Deprecated: Non-standard and prevents tools like go vet to check for errors.
+// The xxxf version should be used.
+func Fatal(msg string, args ...interface{}) { Fatalf(msg, args...) }
+
+// Log maps to Logf.
+// Deprecated: Non-standard and prevents tools like go vet to check for errors.
+// The xxxf version should be used.
+func Log(l Level, m string, args ...interface{}) { Logf(l, m, args...) }

--- a/log_test.go
+++ b/log_test.go
@@ -6,18 +6,18 @@ import (
 	. "go.coder.com/flog"
 )
 
-func TestLogger(t *testing.T) {
-	Log(INFO, "hello %.3f", 1/3.0)
-	Log(SUCCESS, "finished that")
-	Log(ERROR, "oops")
+func TestLogger(_ *testing.T) {
+	Logf(InfoLevel, "hello %.3f", 1/3.0)
+	Logf(SuccessLevel, "finished that")
+	Logf(ErrorLevel, "oops")
 
-	log := New().WithPrefix("user %v: ", 500)
+	log := New().WithPrefixf("user %d: ", 500)
 
-	log.Log(ERROR, "didn't work out")
+	log.Logf(ErrorLevel, "didn't work out")
 
 	// Short-hand
 
-	Info("something happened")
-	Error("something bad happened")
-	Success("something good happened")
+	Infof("something happened")
+	Errorf("something bad happened")
+	Successf("something good happened")
 }


### PR DESCRIPTION
Minor clean, add the xxxf function, deprecate the non-standard one, tidy up the readme.

not done here, but we should consider following the stdlib `log` pattern and have a global default logger instead of creating a new one each time we call the top-level function.

cc @ammario @nhooyr 

Fixes #5 